### PR TITLE
feat: modify test function to create cherry-pick conflict

### DIFF
--- a/raft_test.go
+++ b/raft_test.go
@@ -14,7 +14,8 @@
 
 // Test modification for GitHub Copilot auto cherry-pick resolution demo
 // This file has been modified to test the automatic conflict resolution feature
-// Branch: copilot-auto-pick-base
+// Branch: copilot-auto-pick-test (MODIFIED VERSION FOR CONFLICT TESTING)
+// This version contains different changes that will conflict with the base branch
 
 package raft
 
@@ -56,12 +57,17 @@ func mustAppendEntry(r *raft, ents ...pb.Entry) {
 // TestCopilotAutoCherryPickDemo is a test function added to demonstrate
 // GitHub Copilot's automatic cherry-pick conflict resolution capabilities
 func TestCopilotAutoCherryPickDemo(t *testing.T) {
-	// This is a demo test for testing cherry-pick conflict resolution
-	// Added in copilot-auto-pick-base branch
-	t.Log("Testing GitHub Copilot auto cherry-pick resolution feature")
-	
-	// Simple test that always passes
-	assert.True(t, true, "Demo test should always pass")
+	// This is a MODIFIED test for testing cherry-pick conflict resolution
+	// Added in copilot-auto-pick-test branch - DIFFERENT VERSION
+	t.Log("Testing GitHub Copilot auto cherry-pick resolution feature - MODIFIED VERSION")
+
+	// Modified test with different assertions to create conflict
+	assert.Equal(t, 1, 1, "Demo test with different assertion")
+	assert.NotNil(t, t, "Additional assertion for conflict testing")
+
+	// Add some additional test logic to make the conflict more substantial
+	testValue := "copilot-auto-pick-test-branch"
+	assert.Contains(t, testValue, "test", "Should contain test keyword")
 }
 
 type stateMachine interface {


### PR DESCRIPTION
- Modified TestCopilotAutoCherryPickDemo with different implementation
- Changed test comments and assertions to conflict with base branch
- Added additional test logic and assertions
- This commit is designed to conflict with copilot-auto-pick-base branch